### PR TITLE
Management command updates (various)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,32 @@ When an asset is selected, Wagtail silently downloads the file and related metad
 are saved on the object when this happens, helping Wagtail to recognise when it already has a copy of an asset,
 and to help keep them up-to-date with changes made in Bynder.
 
-Currently, changes are synced from Bynder back to Wagtail via a couple of well optimised management commands,
+Currently, changes are synced from Bynder back to Wagtail via a few well-optimised management commands,
 intended to be run regularly (via a cron job):
 
 - `python manage.py update_stale_images`
 - `python manage.py update_stale_documents`
+- `python manage.py update_stale_videos`
+
+By default, these commands only fetch data for assets updated within the last 24 hours. However, you can use the `minutes`, `hours` or `days` options to narrow or widen this timespan. For example:
+
+To sync images updated within the last 30 minutes only:
+
+```sh
+$ python manage.py update_stale_images --minutes=30
+```
+
+To sync images updated within the last three hours only:
+
+```sh
+$ python manage.py update_stale_images --hours=3
+```
+
+To sync images updated within the last three days:
+
+```sh
+$ python manage.py update_stale_images --days=3
+```
 
 ## Installation
 
@@ -81,7 +102,7 @@ class CustomDocument(BynderSyncedDocument):
 
 Finally, run Django's `makemigrations` and `migrate` commands to apply any model field changes to your project
 
-```shell
+```sh
 $ python manage.py makemigrations
 $ python manage.py migrate
 ```
@@ -129,7 +150,7 @@ BYNDER_VIDEO_MODEL = "videos.Video"
 
 Finally, run Django's `makemigrations` and `migrate` commands to create and apply the model changes in your project.
 
-```shell
+```sh
 $ python manage.py makemigrations
 $ python manage.py migrate
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ testing = [
     "wagtail_factories>=4.1.0,<5.0",
     "responses>=0.24,<1",
     "coverage>=7.0,<8.0",
+    "freezegun>=1.1,<2",
 ]
 
 [project.urls]

--- a/src/wagtail_bynder/management/commands/base.py
+++ b/src/wagtail_bynder/management/commands/base.py
@@ -92,7 +92,7 @@ class BaseBynderSyncCommand(BaseCommand):
         page = 1
         while True:
             query = {
-                "dateModified": self.min_date_modified,
+                "dateModified": self.date_modified_from.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "orderBy": "dateModified desc",
                 "page": page,
                 "limit": self.page_size,

--- a/src/wagtail_bynder/management/commands/base.py
+++ b/src/wagtail_bynder/management/commands/base.py
@@ -92,6 +92,8 @@ class BaseBynderSyncCommand(BaseCommand):
         page = 1
         while True:
             query = {
+                # Datetimes must be supplied in ISO 8601 format without microseconds. See:
+                # https://bynder.docs.apiary.io/#reference/assets/asset-operations/retrieve-assets
                 "dateModified": self.date_modified_from.strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "orderBy": "dateModified desc",
                 "page": page,

--- a/src/wagtail_bynder/management/commands/base.py
+++ b/src/wagtail_bynder/management/commands/base.py
@@ -7,7 +7,6 @@ from django.db.models import Model
 from django.db.models.base import ModelBase
 from django.db.models.query import Q, QuerySet
 from django.utils import timezone
-from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail_bynder.utils import get_bynder_client
@@ -79,10 +78,7 @@ class BaseBynderSyncCommand(BaseCommand):
         # Process any remaining assets
         if asset_dict:
             self.update_outdated_objects(asset_dict)
-
-    @cached_property
-    def min_date_modified(self) -> timezone.datetime:
-        return timezone.now() - timezone.timedelta(days=self.modified_within_days)
+            self.process_batch(asset_dict)
 
     def get_assets(self) -> Generator[dict[str, Any]]:
         """

--- a/src/wagtail_bynder/management/commands/base.py
+++ b/src/wagtail_bynder/management/commands/base.py
@@ -31,7 +31,7 @@ class BaseBynderSyncCommand(BaseCommand):
             type=int,
             help=_(
                 "The number of hours into the past to look for asset "
-                "modifications (takes prescedence over 'minutes')"
+                "modifications (takes precedence over 'minutes')"
             ),
         )
         parser.add_argument(
@@ -39,7 +39,7 @@ class BaseBynderSyncCommand(BaseCommand):
             type=int,
             help=_(
                 "The number of days in the past to look for asset "
-                "modifications (takes prescedence over 'hours' and 'minutes')"
+                "modifications (takes precedence over 'hours' and 'minutes')"
             ),
         )
 
@@ -47,20 +47,24 @@ class BaseBynderSyncCommand(BaseCommand):
         # Default timespan to 1 day (1440 minutes)
         minutes = options.get("minutes")
         hours = options.get("hours")
-        days = options.get("days") or 1
-        if hours:
+        days = options.get("days")
+        if days:
+            timespan = timezone.timedelta(days=days)
+            timespan_desc = f"{days} day(s)"
+        elif hours:
             timespan = timezone.timedelta(hours=hours)
             timespan_desc = f"{hours} hour(s)"
         elif minutes:
             timespan = timezone.timedelta(minutes=minutes)
             timespan_desc = f"{minutes} minute(s)"
         else:
-            timespan = timezone.timedelta(days=days)
-            timespan_desc = f"{days} day(s)"
+            timespan = timezone.timedelta(days=1)
+            timespan_desc = "1 day"
+
         self.date_modified_from = datetime.utcnow() - timespan
 
         self.stdout.write(
-            f"Looking for {self.bynder_asset_type or 'all'} assets modified in the last {timespan_desc}"
+            f"Looking for {self.bynder_asset_type or 'all'} assets modified within the last {timespan_desc}"
         )
 
         self.batch_count = 1

--- a/src/wagtail_bynder/management/commands/update_stale_videos.py
+++ b/src/wagtail_bynder/management/commands/update_stale_videos.py
@@ -1,0 +1,9 @@
+from wagtail_bynder import get_video_model
+
+from .base import BaseBynderSyncCommand
+
+
+class Command(BaseBynderSyncCommand):
+    model = get_video_model()
+    bynder_asset_type: str = "video"
+    page_size: int = 200

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -71,10 +71,6 @@ class SyncCommandTestsMixin:
         # Patch save() to prevent unnecessary database writes
         self.patched_obj.save = mock.Mock()
 
-        # Create an iterable containing the patched object
-        # To be returned by a patched get_stale_objects() method
-        self.mock_stale_objects = (self.patched_obj,)
-
     def call_command(self, *args, **kwargs):
         """
         Calls the command with the provided arguments, whilst also also mocking
@@ -91,7 +87,7 @@ class SyncCommandTestsMixin:
             ),
             mock.patch(
                 "wagtail_bynder.management.commands.base.BaseBynderSyncCommand.get_stale_objects",
-                return_value=self.mock_stale_objects,
+                return_value=(self.patched_obj,),
             ),
         ):
             call_command(

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -1,0 +1,477 @@
+import datetime
+
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import SimpleTestCase, TestCase
+from testapp.factories import CustomDocumentFactory, CustomImageFactory, VideoFactory
+from wagtail.documents import get_document_model
+from wagtail.images import get_image_model
+
+from wagtail_bynder import get_video_model
+from wagtail_bynder.management.commands.update_stale_documents import (
+    Command as UpdateStaleDocuments,
+)
+from wagtail_bynder.management.commands.update_stale_images import (
+    Command as UpdateStaleImages,
+)
+from wagtail_bynder.management.commands.update_stale_videos import (
+    Command as UpdateStaleVideos,
+)
+
+from .utils import TEST_ASSET_ID, get_test_asset_data
+
+
+TEST_ASSET_DATA = get_test_asset_data(id=TEST_ASSET_ID)
+
+
+class BaseSyncCommandTestCase(SimpleTestCase):
+    """
+    A base class for testing 'update_stale_images', 'update_stale_documents' and
+    'update_stale_videos' commands, which uses mocking to patch out interactions
+    with the Bynder API and the database.
+    """
+
+    command_name: str = ""
+    model_class = None
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_api_client = mock.Mock()
+        self.mock_api_client.asset_bank_client.media_list.return_value = [
+            TEST_ASSET_DATA
+        ]
+
+        # Create an in-memory instance of the target model class, so that
+        # the command is acting on a 'real' object
+        self.patched_obj = self.model_class(
+            id=1,
+            title="Test asset",
+            bynder_id=TEST_ASSET_ID,
+            bynder_last_modified=datetime.datetime(2000, 1, 1, tzinfo=datetime.UTC),
+            collection_id=1,
+        )
+
+        # Patch update_from_asset_data() to allow us to check if/how it is called
+        self.patched_obj.update_from_asset_data = mock.Mock(
+            spec=self.patched_obj.update_from_asset_data
+        )
+
+        # Patch save() to prevent unnecessary database writes
+        self.patched_obj.save = mock.Mock()
+
+        # Create an iterable containing the patched object
+        # To be returned by a patched get_stale_objects() method
+        self.mock_stale_objects = (self.patched_obj,)
+
+    def call_command(self, *args, **kwargs):
+        """
+        Calls the command with the provided arguments, whilst also also mocking
+        out the Bynder API client and `get_stale_objects` method, so that we
+        can test the command in isolation and check that interactions happen as
+        expected.
+        """
+        out = StringIO()
+
+        with (
+            mock.patch(
+                "wagtail_bynder.management.commands.base.get_bynder_client",
+                return_value=self.mock_api_client,
+            ),
+            mock.patch(
+                "wagtail_bynder.management.commands.base.BaseBynderSyncCommand.get_stale_objects",
+                return_value=self.mock_stale_objects,
+            ),
+        ):
+            call_command(
+                self.command_name,
+                *args,
+                stdout=out,
+                stderr=StringIO(),
+                **kwargs,
+            )
+        return out.getvalue()
+
+
+class UpdateStaleImagesTestCase(BaseSyncCommandTestCase):
+    """
+    Unit tests for the 'update_stale_images' management command.
+    """
+
+    command_name = "update_stale_images"
+    model_class = get_image_model()
+    common_api_kwargs = {
+        "orderBy": "dateModified desc",
+        "page": 1,
+        "limit": 200,
+        "type": "image",
+    }
+
+    def setUp(self) -> None:
+        super().setUp()
+        # NOTE: update_stale_images overrides update_object() to fetch the
+        # full asset details to pass to the super() implementation, therefore
+        # we need to mock the media_info() method too
+        self.mock_api_client.asset_bank_client.media_info.return_value = TEST_ASSET_DATA
+
+    def test_default(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        output = self.call_command()
+
+        # Check the command output
+        self.assertIn("Looking for image assets modified in the last 1 day(s)", output)
+
+        # Check the mocked API client was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+        self.mock_api_client.asset_bank_client.media_info.assert_called_once_with(
+            TEST_ASSET_ID
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_minutes(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(
+            minutes=30
+        )
+        output = self.call_command(minutes=30)
+
+        # Check the command output
+        self.assertIn(
+            "Looking for image assets modified in the last 30 minute(s)", output
+        )
+
+        # Check the mocked API client was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+        self.mock_api_client.asset_bank_client.media_info.assert_called_once_with(
+            TEST_ASSET_ID
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_hours(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
+        output = self.call_command(hours=3)
+
+        # Check the command output
+        self.assertIn("Looking for image assets modified in the last 3 hour(s)", output)
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+        self.mock_api_client.asset_bank_client.media_info.assert_called_once_with(
+            TEST_ASSET_ID
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_days(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+        output = self.call_command(days=3)
+
+        # Check the command output
+        self.assertIn("Looking for image assets modified in the last 3 day(s)", output)
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+        self.mock_api_client.asset_bank_client.media_info.assert_called_once_with(
+            TEST_ASSET_ID
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+
+class UpdateStaleDocumentsTestCase(BaseSyncCommandTestCase):
+    """
+    Unit tests for the 'update_stale_documents' management command.
+    """
+
+    command_name = "update_stale_documents"
+    model_class = get_document_model()
+    common_api_kwargs = {
+        "orderBy": "dateModified desc",
+        "page": 1,
+        "limit": 200,
+        "type": "document",
+    }
+
+    def test_default(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        output = self.call_command()
+
+        # Check the command output
+        self.assertIn(
+            "Looking for document assets modified in the last 1 day(s)", output
+        )
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_minutes(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(
+            minutes=30
+        )
+        output = self.call_command(minutes=30)
+
+        # Check the command output
+        self.assertIn(
+            "Looking for document assets modified in the last 30 minute(s)", output
+        )
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_hours(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
+        output = self.call_command(hours=3)
+
+        # Check the command output
+        self.assertIn(
+            "Looking for document assets modified in the last 3 hour(s)", output
+        )
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_days(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+        output = self.call_command(days=3)
+
+        # Check the command output
+        self.assertIn(
+            "Looking for document assets modified in the last 3 day(s)", output
+        )
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+
+class UpdateStaleVideosTestCase(BaseSyncCommandTestCase):
+    """
+    Unit tests for the 'update_stale_videos' management command.
+    """
+
+    command_name = "update_stale_videos"
+    model_class = get_video_model()
+    common_api_kwargs = {
+        "orderBy": "dateModified desc",
+        "page": 1,
+        "limit": 200,
+        "type": "video",
+    }
+
+    def test_default(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        output = self.call_command()
+
+        # Check the command output
+        self.assertIn("Looking for video assets modified in the last 1 day(s)", output)
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_minutes(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(
+            minutes=30
+        )
+        output = self.call_command(minutes=30)
+
+        # Check the command output
+        self.assertIn(
+            "Looking for video assets modified in the last 30 minute(s)", output
+        )
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_hours(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
+        output = self.call_command(hours=3)
+
+        # Check the command output
+        self.assertIn("Looking for video assets modified in the last 3 hour(s)", output)
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+    def test_days(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+        output = self.call_command(days=3)
+
+        # Check the command output
+        self.assertIn("Looking for video assets modified in the last 3 day(s)", output)
+
+        # Check the mocked API was called as expected
+        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                **self.common_api_kwargs,
+            }
+        )
+
+        # Check the patched object was updated and saved as expected
+        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        self.patched_obj.save.assert_called_once()
+
+
+class TestGetStaleObjects(TestCase):
+    """
+    Unit tests for the `get_stale_objects` method, which is mocked out in
+    the test cases above.
+    """
+
+    stale_dt = datetime.datetime(2000, 1, 1, tzinfo=datetime.UTC)
+    fresh_dt = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+    fake_asset_batch = {TEST_ASSET_ID: TEST_ASSET_DATA}
+
+    def test_update_stale_images(self):
+        # Save a matching object that we is out-of-date
+        stale_image = CustomImageFactory(
+            bynder_id=TEST_ASSET_ID, bynder_last_modified=self.stale_dt
+        )
+
+        # Call the `get_stale_objects` method directly
+        command_instance = UpdateStaleImages()
+        result = list(command_instance.get_stale_objects(self.fake_asset_batch))
+        self.assertEqual(result, [stale_image])
+
+        # Delete the stale object and create one we know is fresh
+        stale_image.delete()
+        CustomImageFactory(bynder_id=TEST_ASSET_ID, bynder_last_modified=self.fresh_dt)
+
+        # Now call `get_stale_objects` again and test the result
+        self.assertFalse(
+            list(command_instance.get_stale_objects(self.fake_asset_batch))
+        )
+
+    def test_update_stale_documents(self):
+        # Save a matching object that we is out-of-date
+        stale_document = CustomDocumentFactory(
+            bynder_id=TEST_ASSET_ID, bynder_last_modified=self.stale_dt
+        )
+
+        # Call the `get_stale_objects` method directly
+        command_instance = UpdateStaleDocuments()
+        result = list(command_instance.get_stale_objects(self.fake_asset_batch))
+        self.assertEqual(result, [stale_document])
+
+        # Delete the stale object and create one we know is fresh
+        stale_document.delete()
+        CustomDocumentFactory(
+            bynder_id=TEST_ASSET_ID, bynder_last_modified=self.fresh_dt
+        )
+
+        # Now call `get_stale_objects` again and test the result
+        self.assertFalse(
+            list(command_instance.get_stale_objects(self.fake_asset_batch))
+        )
+
+    def test_update_stale_videos(self):
+        # Save a matching object that we is out-of-date
+        stale_video = VideoFactory(
+            bynder_id=TEST_ASSET_ID, bynder_last_modified=self.stale_dt
+        )
+
+        # Call the `get_stale_objects` method directly
+        command_instance = UpdateStaleVideos()
+        result = list(command_instance.get_stale_objects(self.fake_asset_batch))
+        self.assertEqual(result, [stale_video])
+
+        # Delete the stale object and create one we know is fresh
+        stale_video.delete()
+        VideoFactory(bynder_id=TEST_ASSET_ID, bynder_last_modified=self.fresh_dt)
+
+        # Now call `get_stale_objects` again and test the result
+        self.assertFalse(
+            list(command_instance.get_stale_objects(self.fake_asset_batch))
+        )

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -1,16 +1,14 @@
 import datetime
 
 from io import StringIO
+from typing import Type
 from unittest import mock
 
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase
 from freezegun import freeze_time
 from testapp.factories import CustomDocumentFactory, CustomImageFactory, VideoFactory
-from wagtail.documents import get_document_model
-from wagtail.images import get_image_model
 
-from wagtail_bynder import get_video_model
 from wagtail_bynder.management.commands.update_stale_documents import (
     Command as UpdateStaleDocuments,
 )
@@ -20,6 +18,7 @@ from wagtail_bynder.management.commands.update_stale_images import (
 from wagtail_bynder.management.commands.update_stale_videos import (
     Command as UpdateStaleVideos,
 )
+from wagtail_bynder.models import BynderAssetMixin
 
 from .utils import TEST_ASSET_ID, get_test_asset_data
 
@@ -27,22 +26,32 @@ from .utils import TEST_ASSET_ID, get_test_asset_data
 TEST_ASSET_DATA = get_test_asset_data(id=TEST_ASSET_ID)
 
 
-class BaseSyncCommandTestCase(SimpleTestCase):
+class SyncCommandTestsMixin:
     """
-    A base class for testing 'update_stale_images', 'update_stale_documents' and
+    A mixin class for testing 'update_stale_images', 'update_stale_documents' and
     'update_stale_videos' commands, which uses mocking to patch out interactions
     with the Bynder API and the database.
     """
 
     command_name: str = ""
-    model_class = None
+    command_class: Type = None
+    uses_media_info_for_individual_assets: bool = False
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model_class = cls.command_class.model
+        cls.asset_type = cls.command_class.bynder_asset_type
 
     def setUp(self) -> None:
         super().setUp()
+
+        # Define a mock to stand-in for the Bynder API client
         self.mock_api_client = mock.Mock()
         self.mock_api_client.asset_bank_client.media_list.return_value = [
             TEST_ASSET_DATA
         ]
+        self.mock_api_client.asset_bank_client.media_info.return_value = TEST_ASSET_DATA
 
         # Create an in-memory instance of the target model class, so that
         # the command is acting on a 'real' object
@@ -94,318 +103,138 @@ class BaseSyncCommandTestCase(SimpleTestCase):
             )
         return out.getvalue()
 
+    def assertCommandRunOutcome(
+        self,
+        output: StringIO,
+        mocked_client: mock.Mock,
+        model_instance: BynderAssetMixin,
+        expected_datemodified: datetime.datetime,
+        expected_timespan_description: str,
+    ):
+        """
+        Assert that the command output indicates success, and that the mocked
+        API client and `get_stale_objects` method were called as expected.
+        """
+        self.assertIn(
+            f"Looking for {self.asset_type} assets modified within the last {expected_timespan_description}",
+            output,
+        )
+        self.assertIn("Processing batch 1 (1 assets)...", output)
+        self.assertIn("1 stale objects were found for this batch", output)
+        self.assertIn(f"Updating object for asset '{TEST_ASSET_ID}'", output)
 
-@freeze_time()
-class UpdateStaleImagesTestCase(BaseSyncCommandTestCase):
+        # Test that 'media_list' was called as expected
+        mocked_client.asset_bank_client.media_list.assert_called_once_with(
+            {
+                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "orderBy": "dateModified desc",
+                "page": 1,
+                "limit": self.command_class.page_size,
+                "type": self.asset_type,
+            }
+        )
+
+        # Conditionally test that 'media_info' was called as expected
+        if self.uses_media_info_for_individual_assets:
+            mocked_client.asset_bank_client.media_info.assert_called_once_with(
+                TEST_ASSET_ID
+            )
+
+        # Check the patched object was updated and saved as expected
+        model_instance.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
+        model_instance.save.assert_called_once()
+
+    @freeze_time()
+    def test_default(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        expected_timespan_description = "1 day"
+        output = self.call_command()
+
+        self.assertCommandRunOutcome(
+            output,
+            self.mock_api_client,
+            self.patched_obj,
+            expected_datemodified,
+            expected_timespan_description,
+        )
+
+    @freeze_time()
+    def test_minutes(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(
+            minutes=30
+        )
+        expected_timespan_description = "30 minute(s)"
+        output = self.call_command(minutes=30)
+
+        self.assertCommandRunOutcome(
+            output,
+            self.mock_api_client,
+            self.patched_obj,
+            expected_datemodified,
+            expected_timespan_description,
+        )
+
+    @freeze_time()
+    def test_hours(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
+        expected_timespan_description = "3 hour(s)"
+
+        # NOTE: 'minutes' should be ignored when hours is provided
+        output = self.call_command(hours=3, minutes=99999)
+
+        self.assertCommandRunOutcome(
+            output,
+            self.mock_api_client,
+            self.patched_obj,
+            expected_datemodified,
+            expected_timespan_description,
+        )
+
+    @freeze_time()
+    def test_days(self):
+        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+        expected_timespan_description = "3 day(s)"
+
+        # NOTE: 'hours' and 'minutes' should be ignored when days is provided
+        output = self.call_command(days=3, hours=99999, minutes=99999)
+
+        self.assertCommandRunOutcome(
+            output,
+            self.mock_api_client,
+            self.patched_obj,
+            expected_datemodified,
+            expected_timespan_description,
+        )
+
+
+class UpdateStaleImagesTestCase(SyncCommandTestsMixin, SimpleTestCase):
     """
     Unit tests for the 'update_stale_images' management command.
     """
 
     command_name = "update_stale_images"
-    model_class = get_image_model()
-    common_api_kwargs = {
-        "orderBy": "dateModified desc",
-        "page": 1,
-        "limit": 200,
-        "type": "image",
-    }
-
-    def setUp(self) -> None:
-        super().setUp()
-        # NOTE: update_stale_images overrides update_object() to fetch the
-        # full asset details to pass to the super() implementation, therefore
-        # we need to mock the media_info() method too
-        self.mock_api_client.asset_bank_client.media_info.return_value = TEST_ASSET_DATA
-
-    def test_default(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=1)
-        output = self.call_command()
-
-        # Check the command output
-        self.assertIn("Looking for image assets modified in the last 1 day(s)", output)
-
-        # Check the mocked API client was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-        self.mock_api_client.asset_bank_client.media_info.assert_called_once_with(
-            TEST_ASSET_ID
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_minutes(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(
-            minutes=30
-        )
-        output = self.call_command(minutes=30)
-
-        # Check the command output
-        self.assertIn(
-            "Looking for image assets modified in the last 30 minute(s)", output
-        )
-
-        # Check the mocked API client was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-        self.mock_api_client.asset_bank_client.media_info.assert_called_once_with(
-            TEST_ASSET_ID
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_hours(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
-        output = self.call_command(hours=3)
-
-        # Check the command output
-        self.assertIn("Looking for image assets modified in the last 3 hour(s)", output)
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-        self.mock_api_client.asset_bank_client.media_info.assert_called_once_with(
-            TEST_ASSET_ID
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_days(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=3)
-        output = self.call_command(days=3)
-
-        # Check the command output
-        self.assertIn("Looking for image assets modified in the last 3 day(s)", output)
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-        self.mock_api_client.asset_bank_client.media_info.assert_called_once_with(
-            TEST_ASSET_ID
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
+    command_class = UpdateStaleImages
+    uses_media_info_for_individual_assets = True
 
 
-@freeze_time()
-class UpdateStaleDocumentsTestCase(BaseSyncCommandTestCase):
+class UpdateStaleDocumentsTestCase(SyncCommandTestsMixin, SimpleTestCase):
     """
     Unit tests for the 'update_stale_documents' management command.
     """
 
     command_name = "update_stale_documents"
-    model_class = get_document_model()
-    common_api_kwargs = {
-        "orderBy": "dateModified desc",
-        "page": 1,
-        "limit": 200,
-        "type": "document",
-    }
-
-    def test_default(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=1)
-        output = self.call_command()
-
-        # Check the command output
-        self.assertIn(
-            "Looking for document assets modified in the last 1 day(s)", output
-        )
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_minutes(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(
-            minutes=30
-        )
-        output = self.call_command(minutes=30)
-
-        # Check the command output
-        self.assertIn(
-            "Looking for document assets modified in the last 30 minute(s)", output
-        )
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_hours(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
-        output = self.call_command(hours=3)
-
-        # Check the command output
-        self.assertIn(
-            "Looking for document assets modified in the last 3 hour(s)", output
-        )
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_days(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=3)
-        output = self.call_command(days=3)
-
-        # Check the command output
-        self.assertIn(
-            "Looking for document assets modified in the last 3 day(s)", output
-        )
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
+    command_class = UpdateStaleDocuments
+    uses_media_info_for_individual_assets = False
 
 
-@freeze_time()
-class UpdateStaleVideosTestCase(BaseSyncCommandTestCase):
+class UpdateStaleVideosTestCase(SyncCommandTestsMixin, SimpleTestCase):
     """
     Unit tests for the 'update_stale_videos' management command.
     """
 
     command_name = "update_stale_videos"
-    model_class = get_video_model()
-    common_api_kwargs = {
-        "orderBy": "dateModified desc",
-        "page": 1,
-        "limit": 200,
-        "type": "video",
-    }
-
-    def test_default(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=1)
-        output = self.call_command()
-
-        # Check the command output
-        self.assertIn("Looking for video assets modified in the last 1 day(s)", output)
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_minutes(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(
-            minutes=30
-        )
-        output = self.call_command(minutes=30)
-
-        # Check the command output
-        self.assertIn(
-            "Looking for video assets modified in the last 30 minute(s)", output
-        )
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_hours(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(hours=3)
-        output = self.call_command(hours=3)
-
-        # Check the command output
-        self.assertIn("Looking for video assets modified in the last 3 hour(s)", output)
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
-
-    def test_days(self):
-        expected_datemodified = datetime.datetime.utcnow() - datetime.timedelta(days=3)
-        output = self.call_command(days=3)
-
-        # Check the command output
-        self.assertIn("Looking for video assets modified in the last 3 day(s)", output)
-
-        # Check the mocked API was called as expected
-        self.mock_api_client.asset_bank_client.media_list.assert_called_once_with(
-            {
-                "dateModified": expected_datemodified.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                **self.common_api_kwargs,
-            }
-        )
-
-        # Check the patched object was updated and saved as expected
-        self.patched_obj.update_from_asset_data.assert_called_once_with(TEST_ASSET_DATA)
-        self.patched_obj.save.assert_called_once()
+    command_class = UpdateStaleVideos
+    uses_media_info_for_individual_assets = False
 
 
 class TestGetStaleObjects(TestCase):

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase
+from freezegun import freeze_time
 from testapp.factories import CustomDocumentFactory, CustomImageFactory, VideoFactory
 from wagtail.documents import get_document_model
 from wagtail.images import get_image_model
@@ -94,6 +95,7 @@ class BaseSyncCommandTestCase(SimpleTestCase):
         return out.getvalue()
 
 
+@freeze_time()
 class UpdateStaleImagesTestCase(BaseSyncCommandTestCase):
     """
     Unit tests for the 'update_stale_images' management command.
@@ -208,6 +210,7 @@ class UpdateStaleImagesTestCase(BaseSyncCommandTestCase):
         self.patched_obj.save.assert_called_once()
 
 
+@freeze_time()
 class UpdateStaleDocumentsTestCase(BaseSyncCommandTestCase):
     """
     Unit tests for the 'update_stale_documents' management command.
@@ -309,6 +312,7 @@ class UpdateStaleDocumentsTestCase(BaseSyncCommandTestCase):
         self.patched_obj.save.assert_called_once()
 
 
+@freeze_time()
 class UpdateStaleVideosTestCase(BaseSyncCommandTestCase):
     """
     Unit tests for the 'update_stale_videos' management command.


### PR DESCRIPTION
- Resolves #8 
- Resolves #9
- Adds `minutes`, `hours` and `days` arguments to allow the timeframe to be controlled more easily
- Console output improvements
- Method renaming and readability tweaks
- Drastically increase test coverage for manage commands