### PR TITLE
Conditionally sync videos when chosen

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,22 @@ plus blocks and chooser widgets to help use them in your project. However, becau
 and project-specific requirements around video usage can be a little more custom,
 the model is `abstract` - you need to subclass it in order to use the functionality.
 
-First, import the abstract `BynderSyncedVideo` model and subclass it within your project to create a concrete model.
+First, ensure you have `wagtail.snippets` in your project's `INSTALLED_APPS`:
+
+```python: highlight-line=7
+INSTALLED_APPS = [
+  # ...
+  "wagtail.users",
+  "wagtail.admin",
+  "wagtail.documents",
+  "wagtail.images",
+  "wagtail.snippets",
+  "wagtail",
+   # ...
+]
+```
+
+Next, import the abstract `BynderSyncedVideo` model and subclass it within your project to create a concrete model.
 For example:
 
 ```python
@@ -105,7 +120,7 @@ class Video(BynderSyncedVideo):
     pass
 ```
 
-Next, in your project's Django settings, add a `BYNDER_VIDEO_MODEL` item to establish your custom model as the 'official'
+Then, in your project's Django settings, add a `BYNDER_VIDEO_MODEL` item to establish your custom model as the 'official'
 video model. The value should be a string in the format `"app_label.Model"`. For example:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ Default: `False`
 
 As `BYNDER_SYNC_EXISTING_IMAGES_ON_CHOOSE`, but for documents.
 
+### `BYNDER_SYNC_EXISTING_VIDEOS_ON_CHOOSE`
+
+Example: `True`
+
+Default: `False`
+
+As `BYNDER_SYNC_EXISTING_IMAGES_ON_CHOOSE`, but for videos.
+
 ### `BYNDER_DISABLE_WAGTAIL_EDITING_FOR_ASSETS`
 
 Example: `True`

--- a/src/wagtail_bynder/views/video.py
+++ b/src/wagtail_bynder/views/video.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.views.generic.chooser import ChooseView
@@ -37,7 +38,8 @@ class VideoChosenView(SnippetChosenView, BynderAssetCopyMixin):
         except self.model.DoesNotExist:
             obj = self.create_object(pk)
         else:
-            self.update_object(pk, obj)
+            if getattr(settings, "BYNDER_SYNC_EXISTING_VIDEOS_ON_CHOOSE", False):
+                self.update_object(pk, obj)
         return self.get_chosen_response(obj)
 
 

--- a/tests/test_video_chooser_views.py
+++ b/tests/test_video_chooser_views.py
@@ -19,7 +19,9 @@ class TestVideoChooseView(TestCase, WagtailTestUtils):
 
 
 class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
-    url = reverse_lazy("wagtailsnippetchoosers_testapp_video:chosen", args=[TEST_ASSET_ID])
+    url = reverse_lazy(
+        "wagtailsnippetchoosers_testapp_video:chosen", args=[TEST_ASSET_ID]
+    )
 
     def setUp(self):
         # Always log in as an admin user
@@ -47,7 +49,9 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                 "result": {
                     "id": str(video.id),
                     "string": video.title,
-                    "edit_url": reverse("wagtailsnippets_testapp_video:edit", args=[video.id]),
+                    "edit_url": reverse(
+                        "wagtailsnippets_testapp_video:edit", args=[video.id]
+                    ),
                 },
             },
         )
@@ -73,7 +77,9 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                 "result": {
                     "id": str(video.id),
                     "string": video.title,
-                    "edit_url": reverse("wagtailsnippets_testapp_video:edit", args=[video.id]),
+                    "edit_url": reverse(
+                        "wagtailsnippets_testapp_video:edit", args=[video.id]
+                    ),
                 },
             },
         )
@@ -99,7 +105,9 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                 "result": {
                     "id": str(video.id),
                     "string": video.title,
-                    "edit_url": reverse("wagtailsnippets_testapp_video:edit", args=[video.id]),
+                    "edit_url": reverse(
+                        "wagtailsnippets_testapp_video:edit", args=[video.id]
+                    ),
                 },
             },
         )

--- a/tests/test_video_chooser_views.py
+++ b/tests/test_video_chooser_views.py
@@ -1,0 +1,105 @@
+from unittest import mock
+
+from django.test import TestCase, TransactionTestCase, override_settings
+from django.urls import reverse, reverse_lazy
+from testapp.factories import VideoFactory
+from wagtail.test.utils import WagtailTestUtils
+
+from .utils import TEST_ASSET_ID
+
+
+class TestVideoChooseView(TestCase, WagtailTestUtils):
+    url = reverse_lazy("wagtailsnippetchoosers_testapp_video:choose")
+
+    def test_view_loads_without_errors(self):
+        user = self.create_test_user()
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+
+class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
+    url = reverse_lazy("wagtailsnippetchoosers_testapp_video:chosen", args=[TEST_ASSET_ID])
+
+    def setUp(self):
+        # Always log in as an admin user
+        self.user = self.create_test_user()
+        self.client.force_login(self.user)
+        super().setUp()
+
+    def test_creates_video_if_asset_id_not_recognised(self):
+        # For expediency and predictability, have create_object()
+        # return a test image instead of creating its own
+        video = VideoFactory.create()
+        with mock.patch(
+            "wagtail_bynder.views.video.VideoChosenView.create_object",
+            return_value=video,
+        ) as create_object_mock:
+            response = self.client.get(str(self.url))
+
+        # Assertions
+        create_object_mock.assert_called_once()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "step": "chosen",
+                "result": {
+                    "id": str(video.id),
+                    "string": video.title,
+                    "edit_url": reverse("wagtailsnippets_testapp_video:edit", args=[video.id]),
+                },
+            },
+        )
+
+    @mock.patch("wagtail_bynder.views.video.VideoChosenView.update_object")
+    def test_uses_existing_video_without_updating(self, update_object_mock):
+        # Create a video with a matching bynder_id
+        video = VideoFactory.create(bynder_id=TEST_ASSET_ID)
+
+        # Make a request to the view
+        response = self.client.get(str(self.url))
+
+        # update_object() should NOT have been called, because
+        # 'refresh on choose' is disabled by default
+        update_object_mock.assert_not_called()
+
+        # Check response content
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "step": "chosen",
+                "result": {
+                    "id": str(video.id),
+                    "string": video.title,
+                    "edit_url": reverse("wagtailsnippets_testapp_video:edit", args=[video.id]),
+                },
+            },
+        )
+
+    @override_settings(BYNDER_SYNC_EXISTING_VIDEOS_ON_CHOOSE=True)
+    @mock.patch("wagtail_bynder.views.video.VideoChosenView.update_object")
+    def test_uses_existing_video_and_updates_it(self, update_object_mock):
+        # Create an image with a matching bynder_id
+        video = VideoFactory.create(bynder_id=TEST_ASSET_ID)
+
+        # Make a request to the view
+        response = self.client.get(str(self.url))
+
+        # update_object() should have been called this time
+        update_object_mock.assert_called_once()
+
+        # Check response content
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "step": "chosen",
+                "result": {
+                    "id": str(video.id),
+                    "string": video.title,
+                    "edit_url": reverse("wagtailsnippets_testapp_video:edit", args=[video.id]),
+                },
+            },
+        )

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "wagtail.images",
     "wagtail.admin",
     "wagtail.sites",
+    "wagtail.snippets",
     "wagtail",
     "taggit",
     "django.contrib.admin",


### PR DESCRIPTION
`VideoChosenView` currently always updates existing items from the library when chosen, which could be considered wasteful in environments that are regularly synced. These changes add a new `BYNDER_SYNC_EXISTING_VIDEOS_ON_CHOOSE` setting to toggle this behaviour, in-line with the equivalent views for images and documents.