### PR TITLE
[tooling] Ensure version consistency in tox/ruff

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - run: python -Im pip install --user ruff
+    # Keep in sync with .pre-comit-config.yaml
+    - run: python -Im pip install --user ruff==0.4.1
 
     - name: Run ruff
       working-directory: ./src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,8 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.3.7'
+    # keep in sync with .github/workflows/ruff.yml
+    rev: 'v0.4.1'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,19 +19,19 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6",
 ]
 
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
-    "Django>=3.2",
-    "Wagtail>=4.1",
+    "Django>=4.2",
+    "Wagtail>=5.2",
     "bynder-sdk>=1.1.5,<2.0"
 ]
 

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("taggit", "0005_auto_20220424_2025"),
-        ("wagtailcore", "0091_remove_revision_submitted_for_moderation"),
+        ("wagtailcore", "0089_log_entry_data_json_null_to_object"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-min_version = 4.0
+min_version = 4.11
 
 envlist =
     py{3.11}-django{3.2}-wagtail{4.1, 5.2}
@@ -18,6 +18,8 @@ DB =
 [testenv]
 package = wheel
 wheel_build_env = .pkg
+use_frozen_constraints = true
+constrain_package_deps = true
 
 pass_env =
     FORCE_COLOR
@@ -26,6 +28,8 @@ pass_env =
 setenv =
     PYTHONPATH = {toxinidir}/tests:{toxinidir}
     PYTHONDEVMODE = 1
+
+extras = testing
 
 deps =
     flit>=3.9
@@ -40,8 +44,6 @@ deps =
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.9
-
-    .[testing]
 
 install_command = python -Im pip install -U --pre {opts} {packages}
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,12 @@
 min_version = 4.11
 
 envlist =
-    py{3.11}-django{3.2}-wagtail{4.1, 5.2}
-    py{3.11,3.12}-django{4.2,5.0}-wagtail{5.2}
+    py{3.11,3.12}-django{4.2,5.0}-wagtail{5.2,6.0}
 
 [gh-actions]
 python =
-    3.11: py311
-    3.12: py312
+    3.11: py3.11
+    3.12: py3.12
 
 [gh-actions:env]
 DB =
@@ -32,15 +31,11 @@ setenv =
 extras = testing
 
 deps =
-    flit>=3.9
-
-    django3.2: Django>=3.2,<3.3
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
-    djmain: git+https://github.com/django/django.git@main#egg=Django
 
-    wagtail4.1: wagtail>=4.1,<4.2
     wagtail5.2: wagtail>=5.2,<5.3
+    wagtail6.0: wagtail>=6.0,<6.1
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.9
@@ -52,13 +47,17 @@ commands =
     python -m coverage run {toxinidir}/tests/manage.py test --deprecation all {posargs: -v 2}
 
 [testenv:coverage-report]
+base_python = python3.12
+package = skip
+deps =
+    coverage>=7.0,<8.0
 commands =
     python -Im coverage combine
     python -Im coverage report -m
 
 [testenv:interactive]
 description = An interactive environment for local testing purposes
-basepython = python3.11
+basepython = python3.12
 
 commands_pre =
     python {toxinidir}/tests/manage.py makemigrations


### PR DESCRIPTION
- uses frozen constraints in tox (i.e. tox generates a requirements.txt file for the env, ensuring no loose dependencies get installed)
- bumps ruff to 0.4.1 in pre-commit and pins it in the ruff CI job
- bump min versions to Django 4.2, Wagtail 5.2