### PR TITLE
Improve conversion of focus points into focal areas

### DIFF
--- a/src/wagtail_bynder/models.py
+++ b/src/wagtail_bynder/models.py
@@ -242,7 +242,7 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
         self, x: int, y: int, original_height: int, original_width: int
     ) -> None:
         """
-        Using the provided center-point coordinates, generate a
+        Using the provided focus point coordinates, generate a
         2D focal area for the downloaded image.
         """
         if x < 0 or y < 0 or x > original_width or y > original_height:
@@ -261,11 +261,21 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
         self.focal_point_x = x
         self.focal_point_y = y
 
+        # Draw a rectangle around the centre point
         # For the width, span outwards until we hit the left or right bounds
-        self.focal_point_width = min(x, self.width - x) * 2
+        rect_width = min(x, self.width - x) * 2
+        # Restrict rectangle width to 40% of the image height
+        rect_width = min(rect_width, math.floor(self.width * 0.4))
 
         # For the height, span outwards until we hit the top or bottom bounds
-        self.focal_point_height = min(y, self.height - y) * 2
+        rect_height = min(y, self.height - y) * 2
+        # Restrict rectangle height to 40% of the image height
+        rect_height = min(rect_height, math.floor(self.height * 0.4))
+
+        # Use the shortest side to make a square
+        width = min(rect_width, rect_height)
+        self.focal_point_width = width
+        self.focal_point_height = width
 
     @staticmethod
     def extract_file_source(asset_data: dict[str, Any]) -> str:


### PR DESCRIPTION
The current conversion behaviour is too conservative. When a focus point in Bynder is set close to the centre of the image, the area it currently draws around that point will end up covering most of the image (the entire image, if dead centre), which isn't really helpful, and actually leads to Wagtail creating some strange crops (as it tries to preserve everything)!

In a bid to improve this on a current project, I came up with this new approach, which instead draws a width-restricted (to 40% of the image) square around the focus point, which produces 'tighter' crops without losing too much of the image.