### PR TITLE
Fix: Allow RedirectToBynderMixin views to process post requests as normal when not redirecting to Bynder

### DIFF
--- a/src/wagtail_bynder/views/mixins.py
+++ b/src/wagtail_bynder/views/mixins.py
@@ -49,4 +49,4 @@ class RedirectToBynderMixin:
             return redirect(
                 "https://" + settings.BYNDER_DOMAIN + f"/media/?mediaId={asset_id}"
             )
-        return super().get(request, *args, **kwargs)
+        return super().post(request, *args, **kwargs)


### PR DESCRIPTION
Fixes what looks like a typo... the `post()` method should call the super implementation of `post()` instead of `get()`.