### PR TITLE
Protection against memory spikes when downloading assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- BYNDER_MAX_DOCUMENT_FILE_SIZE and BYNDER_MAX_IMAGE_FILE_SIZE settings to guard against memory spikes when downloading asset files ([#31]https://github.com/torchbox/wagtail-bynder/pull/31) @ababic
+
 ## [0.5.1] - 2024-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ When communicating with Bynder about configuring a new instance for compatibilit
 2. A custom derivative must to be configured for image assets
 3. A couple of custom derivatives must be configured for video assets
 
-
 ### Why are custom derivatives needed?
 
 It is common for assets to be uploaded to a DAMS in formats that preserve as much quality as possible. For example, high-resolution uncompressed TIFF images are common for digital photography. While great for print and other media, such formats are simply overkill for most websites. Not only are images likely to be shown at much smaller dimensions in a web browser, but they are also likely to be converted to more web-friendly formats like AVIF or WebP by Wagtail, where the image quality of an uncompressed TIFF is unlikely to shine through.
@@ -252,6 +251,30 @@ representative Wagtail image (as it appears in `thumbnails` in the API represent
 WARNING: It's important to get this right, because if the specified derivative is NOT present in the response for an
 image for any reason, the ORIGINAL will be downloaded - which will lead to slow chooser response times and higher memory
 usage when generating renditions.
+
+### `BYNDER_MAX_DOCUMENT_FILE_SIZE`
+
+Example: `10485760`
+
+Default: `5242880`
+
+The maximum acceptable file size (in Bytes) when downloading a 'Document' asset from Bynder. This is safety measure to protect projects against memory spikes when file contents is loaded into memory, and can be tweaked on a project/environment basis to reflect:
+
+- How much RAM is available in the host infrastructure
+- How large the documents are that editors want to feature in content
+- Whether you are doing anything particularly memory intensive with document files (e.g. text/content analysis)
+
+### `BYNDER_MAX_IMAGE_FILE_SIZE`
+
+Example: `10485760`
+
+Default: `5242880`
+
+The maximum acceptable file size (in Bytes) when downloading an 'Image' asset from Bynder. This is safety measure to protect projects against memory spikes when file contents is loaded into memory.
+
+This setting is provided separately to `BYNDER_MAX_DOCUMENT_FILE_SIZE`, because it often needs to be set to a lower value, even if enough RAM is available to hold the orignal file in memory. This is because server-size image libraries have to understand the individual pixel values of the image, which often requires much more memory than that of the original contents.
+
+As with `BYNDER_MAX_DOCUMENT_FILE_SIZE`, this can be tweaked for individual projects/environments to reflect how much RAM is available in the host infrastructure.
 
 ### `BYNDER_VIDEO_MODEL`
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The maximum acceptable file size (in Bytes) when downloading a 'Document' asset 
 
 - How much RAM is available in the host infrastructure
 - How large the documents are that editors want to feature in content
-- Whether you are doing anything particularly memory intensive with document files (e.g. text/content analysis)
+- Whether you are doing anything particularly memory intensive with document files in your project (e.g. text/content analysis)
 
 ### `BYNDER_MAX_IMAGE_FILE_SIZE`
 

--- a/src/wagtail_bynder/exceptions.py
+++ b/src/wagtail_bynder/exceptions.py
@@ -3,3 +3,10 @@ class BynderAssetDataError(Exception):
     Raised when values expected to be present in an asset API representation
     from Bynder are missing.
     """
+
+
+class BynderAssetFileTooLarge(Exception):
+    """
+    Raised when an asset file being downloaded from Bynder is found to be
+    larger than specified in ``settings.BYNDER_MAX_DOWNLOAD_FILE_SIZE``
+    """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -65,10 +65,12 @@ class BynderSyncedDocumentTests(SimpleTestCase):
         self.obj.original_filesize = None
         self.assertFalse(hasattr(self.obj, "_file_changed"))
 
-        with mock.patch(
-            "wagtail_bynder.models.utils.download_asset", return_value=None
-        ):
+        with mock.patch.object(
+            self.obj, "download_file", return_value=None
+        ) as download_file_mock:
             self.obj.update_file(self.asset_data)
+
+        download_file_mock.assert_called_once_with(self.asset_data["original"])
 
         self.assertTrue(self.obj._file_changed)
         self.assertEqual(
@@ -175,10 +177,14 @@ class BynderSyncedImageTests(SimpleTestCase):
         self.obj.original_width = None
         self.assertFalse(hasattr(self.obj, "_file_changed"))
 
-        with mock.patch(
-            "wagtail_bynder.models.utils.download_asset", return_value=None
-        ):
+        with mock.patch.object(
+            self.obj, "download_file", return_value=None
+        ) as download_file_mock:
             self.obj.update_file(self.asset_data)
+
+        download_file_mock.assert_called_once_with(
+            self.asset_data["thumbnails"]["WagtailSource"]
+        )
 
         self.assertTrue(self.obj._file_changed)
         self.assertEqual(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,11 @@ from wagtail_bynder import get_video_model
 from wagtail_bynder.exceptions import BynderAssetDataError
 from wagtail_bynder.utils import filename_from_url
 
-from .utils import get_test_asset_data
+from .utils import (
+    get_fake_downloaded_document,
+    get_fake_downloaded_image,
+    get_test_asset_data,
+)
 
 
 class BynderSyncedDocumentTests(SimpleTestCase):
@@ -65,12 +69,22 @@ class BynderSyncedDocumentTests(SimpleTestCase):
         self.obj.original_filesize = None
         self.assertFalse(hasattr(self.obj, "_file_changed"))
 
-        with mock.patch.object(
-            self.obj, "download_file", return_value=None
-        ) as download_file_mock:
+        fake_document = get_fake_downloaded_document()
+
+        with (
+            mock.patch.object(
+                self.obj, "download_file", return_value=fake_document
+            ) as download_file_mock,
+            mock.patch.object(
+                self.obj, "process_downloaded_file", return_value=fake_document
+            ) as process_downloaded_file_mock,
+        ):
             self.obj.update_file(self.asset_data)
 
         download_file_mock.assert_called_once_with(self.asset_data["original"])
+        process_downloaded_file_mock.assert_called_once_with(
+            fake_document, self.asset_data
+        )
 
         self.assertTrue(self.obj._file_changed)
         self.assertEqual(
@@ -177,13 +191,22 @@ class BynderSyncedImageTests(SimpleTestCase):
         self.obj.original_width = None
         self.assertFalse(hasattr(self.obj, "_file_changed"))
 
-        with mock.patch.object(
-            self.obj, "download_file", return_value=None
-        ) as download_file_mock:
+        fake_image = get_fake_downloaded_image()
+        with (
+            mock.patch.object(
+                self.obj, "download_file", return_value=fake_image
+            ) as download_file_mock,
+            mock.patch.object(
+                self.obj, "process_downloaded_file", return_value=fake_image
+            ) as process_downloaded_file_mock,
+        ):
             self.obj.update_file(self.asset_data)
 
         download_file_mock.assert_called_once_with(
             self.asset_data["thumbnails"]["WagtailSource"]
+        )
+        process_downloaded_file_mock.assert_called_once_with(
+            fake_image, self.asset_data
         )
 
         self.assertTrue(self.obj._file_changed)


### PR DESCRIPTION
Rewrites asset download functions to stream file contents into memory, instead of reading it all in one go.

It also adds the `BYNDER_MAX_DOCUMENT_FILE_SIZE` and `BYNDER_MAX_IMAGE_FILE_SIZE` settings, which provides a way for apps to place an upper boundary on the sizes of files they attempt to load into memory, reducing the likelihood of spikes during download. The default value of 5MB is quite conservative, but can be increased to fit the project setup (as outlined in the updated docs)