### PR TITLE
Automatic downsizing of larger-than-necessary images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - BYNDER_MAX_DOCUMENT_FILE_SIZE and BYNDER_MAX_IMAGE_FILE_SIZE settings to guard against memory spikes when downloading asset files ([#31]https://github.com/torchbox/wagtail-bynder/pull/31) @ababic
+- Automatic reformatting and downsizing of source images ([#32](https://github.com/torchbox/wagtail-bynder/pull/32)) @ababic
 
 ## [0.5.1] - 2024-07-29
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When the `BYNDER_IMAGE_SOURCE_THUMBNAIL_NAME` derivative for an image is success
 
 Firstly, downloaded images are converted to the most appropriate type, according to your project's `WAGTAILIMAGES_FORMAT_CONVERSIONS` setting and Wagtail's default preferences. For example, by default, `BMP` and `WebP` image are converted to `PNG`.
 
-Secondly, images are downsized according to the `BYNDER_MAX_IMAGE_WIDTH` and `BYNDER_MAX_IMAGE_HEIGHT` setting values, in a way that preserves their original aspect ratio. Whilst Bynder is expected to address this on their side by generating appropriately-sized derivatives - this isn't always a possibile with their basic offering.
+Secondly, images are downsized according to the `BYNDER_MAX_SOURCE_IMAGE_WIDTH` and `BYNDER_MAX_SOURCE_IMAGE_HEIGHT` setting values, in a way that preserves their original aspect ratio. Whilst Bynder is expected to address this on their side by generating appropriately-sized derivatives - this isn't always a possibile with their basic offering.
 
 Ensuring source images only have enough pixels to meet the rendition-generation requirements of your project has an enormous long-term benefit for a Wagtail project (especially one with image-heavy content pages), as it provides efficiency gains **every single time** a new rendition is generated.
 
@@ -286,7 +286,7 @@ This setting is provided separately to `BYNDER_MAX_DOCUMENT_FILE_SIZE`, because 
 
 As with `BYNDER_MAX_DOCUMENT_FILE_SIZE`, this can be tweaked for individual projects/environments to reflect how much RAM is available in the host infrastructure.
 
-### `BYNDER_MAX_IMAGE_WIDTH`
+### `BYNDER_MAX_SOURCE_IMAGE_WIDTH`
 
 Example: `5000`
 
@@ -294,7 +294,7 @@ Default: `3500`
 
 Used to restrict the **width** of images downloaded from Bynder before they are used as source images for objects in Wagtail's image library.
 
-### `BYNDER_MAX_IMAGE_HEIGHT`
+### `BYNDER_MAX_SOURCE_IMAGE_HEIGHT`
 
 Example: `5000`
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ To sync images updated within the last three days:
 $ python manage.py update_stale_images --days=3
 ```
 
+### Automatic conversion and downsizing of images
+
+When the `BYNDER_IMAGE_SOURCE_THUMBNAIL_NAME` derivative for an image is successfully downloaded by Wagtail, it is passed to the `convert_downloaded_image()` method of your custom image model in order to convert it into something more suitable for Wagtail.
+
+Firstly, downloaded images are converted to the most appropriate type, according to your project's `WAGTAILIMAGES_FORMAT_CONVERSIONS` setting and Wagtail's default preferences. For example, by default, `BMP` and `WebP` image are converted to `PNG`.
+
+Secondly, images are downsized according to the `BYNDER_MAX_IMAGE_WIDTH` and `BYNDER_MAX_IMAGE_HEIGHT` setting values, in a way that preserves their original aspect ratio. Whilst Bynder is expected to address this on their side by generating appropriately-sized derivatives - this isn't always a possibile with their basic offering.
+
+Ensuring source images only have enough pixels to meet the rendition-generation requirements of your project has an enormous long-term benefit for a Wagtail project (especially one with image-heavy content pages), as it provides efficiency gains **every single time** a new rendition is generated.
+
 ## What to ask of Bynder
 
 When communicating with Bynder about configuring a new instance for compatibility with Wagtail, there are a few things you'll want to be clear about:
@@ -241,17 +251,6 @@ An API token for Bynder's JavaScript 'compact view' to use. The value is injecte
 for the JavaScript to pick up, exposing it to Wagtail users. Because of this, it should be different to `BYNDER_API_TOKEN`
 and only needs to have basic read permissions.
 
-### `BYNDER_IMAGE_SOURCE_THUMBNAIL_NAME`
-
-Default: `"WagtailSource"`
-
-The name of the automatically generated derivative that should be downloaded and used as the `file` value for the
-representative Wagtail image (as it appears in `thumbnails` in the API representation).
-
-WARNING: It's important to get this right, because if the specified derivative is NOT present in the response for an
-image for any reason, the ORIGINAL will be downloaded - which will lead to slow chooser response times and higher memory
-usage when generating renditions.
-
 ### `BYNDER_MAX_DOCUMENT_FILE_SIZE`
 
 Example: `10485760`
@@ -264,6 +263,17 @@ The maximum acceptable file size (in Bytes) when downloading a 'Document' asset 
 - How large the documents are that editors want to feature in content
 - Whether you are doing anything particularly memory intensive with document files in your project (e.g. text/content analysis)
 
+### `BYNDER_IMAGE_SOURCE_THUMBNAIL_NAME`
+
+Default: `"WagtailSource"`
+
+The name of the automatically generated derivative that should be downloaded and used as the `file` value for the
+representative Wagtail image (as it appears in `thumbnails` in the API representation).
+
+WARNING: It's important to get this right, because if the specified derivative is NOT present in the response for an
+image for any reason, the ORIGINAL will be downloaded - which will lead to slow chooser response times and higher memory
+usage when generating renditions.
+
 ### `BYNDER_MAX_IMAGE_FILE_SIZE`
 
 Example: `10485760`
@@ -275,6 +285,22 @@ The maximum acceptable file size (in Bytes) when downloading an 'Image' asset fr
 This setting is provided separately to `BYNDER_MAX_DOCUMENT_FILE_SIZE`, because it often needs to be set to a lower value, even if enough RAM is available to hold the orignal file in memory. This is because server-size image libraries have to understand the individual pixel values of the image, which often requires much more memory than that of the original contents.
 
 As with `BYNDER_MAX_DOCUMENT_FILE_SIZE`, this can be tweaked for individual projects/environments to reflect how much RAM is available in the host infrastructure.
+
+### `BYNDER_MAX_IMAGE_WIDTH`
+
+Example: `5000`
+
+Default: `3500`
+
+Used to restrict the **width** of images downloaded from Bynder before they are used as source images for objects in Wagtail's image library.
+
+### `BYNDER_MAX_IMAGE_HEIGHT`
+
+Example: `5000`
+
+Default: `3500`
+
+Used to restrict the **height** of images downloaded from Bynder before they are used as source images for objects in Wagtail's image library.
 
 ### `BYNDER_VIDEO_MODEL`
 

--- a/src/wagtail_bynder/models.py
+++ b/src/wagtail_bynder/models.py
@@ -325,7 +325,7 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
         )
 
     def get_source_image_filter_string(
-        self, original_format: str, is_animated: bool
+        self, original_format: str, *, is_animated: bool
     ) -> str:
         """
         Return a string for ``convert_downloaded_image()`` to use to create a
@@ -338,7 +338,10 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
         max_height = int(getattr(settings, "BYNDER_MAX_SOURCE_IMAGE_HEIGHT", 3500))
 
         filter_str = f"max-{max_width}x{max_height}"
-        if utils.get_output_image_format(original_format, is_animated) == "jpeg":
+        if (
+            utils.get_output_image_format(original_format, is_animated=is_animated)
+            == "jpeg"
+        ):
             # Since this will be a source image, use a higher JPEG quality than normal
             filter_str += " format-jpeg jpegquality-90"
 
@@ -362,7 +365,9 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
         """
 
         width, height, original_format, is_animated = utils.get_image_info(source_file)
-        filter_str = self.get_source_image_filter_string(original_format, is_animated)
+        filter_str = self.get_source_image_filter_string(
+            original_format, is_animated=is_animated
+        )
 
         # Filter.run() expects the object's width and height to reflect
         # the image we're formatting, so we update them temporarily

--- a/src/wagtail_bynder/models.py
+++ b/src/wagtail_bynder/models.py
@@ -343,7 +343,7 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
             == "jpeg"
         ):
             # Since this will be a source image, use a higher JPEG quality than normal
-            filter_str += " format-jpeg jpegquality-90"
+            filter_str += "|format-jpeg|jpegquality-90"
 
         return filter_str
 

--- a/src/wagtail_bynder/models.py
+++ b/src/wagtail_bynder/models.py
@@ -324,7 +324,9 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
             charset=None,
         )
 
-    def get_source_image_filter_string(self, original_format: str, is_animated: bool):
+    def get_source_image_filter_string(
+        self, original_format: str, is_animated: bool
+    ) -> str:
         """
         Return a string for ``convert_downloaded_image()`` to use to create a
         ``wagtail.images.models.Filter`` object that can be used for source image
@@ -336,10 +338,7 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
         max_height = int(getattr(settings, "BYNDER_MAX_SOURCE_IMAGE_HEIGHT", 3500))
 
         filter_str = f"max-{max_width}x{max_height}"
-        if (
-            utils.get_output_image_format(original_format, is_animated=is_animated)
-            == "jpeg"
-        ):
+        if utils.get_output_image_format(original_format, is_animated) == "jpeg":
             # Since this will be a source image, use a higher JPEG quality than normal
             filter_str += " format-jpeg jpegquality-90"
 

--- a/src/wagtail_bynder/utils.py
+++ b/src/wagtail_bynder/utils.py
@@ -67,7 +67,7 @@ def get_image_info(file: File) -> tuple[int, int, str, bool]:
     return (width, height, willow_image.format_name, willow_image.has_animation())
 
 
-def get_output_image_format(original_format: str, is_animated: bool) -> str:
+def get_output_image_format(original_format: str, *, is_animated: bool = False) -> str:
     conversions = {
         "avif": "png",
         "bmp": "png",

--- a/src/wagtail_bynder/utils.py
+++ b/src/wagtail_bynder/utils.py
@@ -8,9 +8,11 @@ import requests
 from asgiref.local import Local
 from bynder_sdk import BynderClient
 from django.conf import settings
+from django.core.files import File
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.template.defaultfilters import filesizeformat
 from wagtail.models import Collection
+from willow import Image
 
 from .exceptions import BynderAssetFileTooLarge
 
@@ -57,6 +59,11 @@ def download_image(url: str) -> InMemoryUploadedFile:
     max_filesize_setting_name = "BYNDER_MAX_IMAGE_FILE_SIZE"
     max_filesize = getattr(settings, max_filesize_setting_name, 5242880)
     return download_file(url, max_filesize, max_filesize_setting_name)
+
+
+def get_image_dimensions(file: File) -> tuple[int, int]:
+    willow_image = Image.open(file)
+    return willow_image.get_size()
 
 
 def filename_from_url(url: str) -> str:

--- a/src/wagtail_bynder/utils.py
+++ b/src/wagtail_bynder/utils.py
@@ -61,9 +61,27 @@ def download_image(url: str) -> InMemoryUploadedFile:
     return download_file(url, max_filesize, max_filesize_setting_name)
 
 
-def get_image_dimensions(file: File) -> tuple[int, int]:
+def get_image_info(file: File) -> tuple[int, int, str, bool]:
     willow_image = Image.open(file)
-    return willow_image.get_size()
+    width, height = willow_image.get_size()
+    return (width, height, willow_image.format_name, willow_image.has_animation())
+
+
+def get_output_image_format(original_format: str, *, is_animated: bool = False):
+    conversions = {
+        "avif": "png",
+        "bmp": "png",
+        "webp": "png",
+    }
+    if is_animated:
+        # Convert non-animated GIFs to PNG as well
+        conversions["gif"] = "png"
+
+    # Allow the user to override the conversions
+    custom_conversions = getattr(settings, "WAGTAILIMAGES_FORMAT_CONVERSIONS", {})
+    conversions.update(custom_conversions)
+
+    return conversions.get(original_format, original_format)
 
 
 def filename_from_url(url: str) -> str:

--- a/src/wagtail_bynder/utils.py
+++ b/src/wagtail_bynder/utils.py
@@ -67,7 +67,7 @@ def get_image_info(file: File) -> tuple[int, int, str, bool]:
     return (width, height, willow_image.format_name, willow_image.has_animation())
 
 
-def get_output_image_format(original_format: str, *, is_animated: bool = False):
+def get_output_image_format(original_format: str, is_animated: bool) -> str:
     conversions = {
         "avif": "png",
         "bmp": "png",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,9 @@
+import io
+
 from unittest import mock
 
 from django.conf import settings
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from wagtail.documents import get_document_model
 from wagtail.images import get_image_model
 
@@ -292,6 +294,74 @@ class BynderSyncedImageTests(SimpleTestCase):
         new_focal_point = self.obj.get_focal_point()
         self.assertEqual(new_focal_point, current_focal_point)
         self.assertFalse(self.obj._focal_point_changed)
+
+    def test_process_downloaded_file(self):
+        fake_image = get_fake_downloaded_image("example.jpg", 500, 200)
+        state_before = self.obj.__dict__
+
+        # The original image data should be available via the `file` attribute
+        self.assertTrue(fake_image.file)
+
+        result = self.obj.process_downloaded_file(fake_image, self.asset_data)
+
+        # Wagtail doesn't convert JPEGs to a differet format by default, so the
+        # resulting name and content type should be the same as what was provided
+        self.assertEqual(result.name, fake_image.name)
+        self.assertEqual(result.content_type, fake_image.content_type)
+
+        # The original image data should have been deleted to create headroom
+        # for the converted image
+        self.assertFalse(hasattr(fake_image, "file"))
+
+        # No attribute values should on the object itself should have changed
+        self.assertEqual(state_before, self.obj.__dict__)
+
+    @override_settings(
+        BYNDER_IMAGE_MAX_WIDTH=100,
+        BYNDER_IMAGE_MAX_HEIGHT=100,
+        WAGTAILIMAGES_FORMAT_CONVERSIONS={"gif": "png", "bmp": "png", "tiff": "jpeg"},
+    )
+    def test_convert_downloaded_image(self):
+        for original_details, expected_details in (
+            (
+                ("tall.gif", "gif", "image/gif", 240, 400),
+                ("tall.png", "png", "image/png", 60, 100),
+            ),
+            (
+                ("wide.bmp", "bmp", "image/bmp", 400, 100),
+                ("wide.png", "png", "image/png", 100, 25),
+            ),
+            (
+                ("big-square.tif", "tiff", "image/tiff", 400, 400),
+                ("big-square.jpg", "jpeg", "image/jpeg", 100, 100),
+            ),
+            (
+                ("small-square.tiff", "tiff", "image/tiff", 80, 80),
+                ("small-square.jpg", "jpeg", "image/jpeg", 80, 80),
+            ),
+        ):
+            with self.subTest(f"{original_details[0]} becomes {expected_details[0]}"):
+                original = get_fake_downloaded_image(
+                    name=original_details[0],
+                    width=original_details[3],
+                    height=original_details[4],
+                )
+                self.assertEqual(original.content_type, original_details[2])
+                result = self.obj.convert_downloaded_image(original, io.BytesIO())
+                self.assertEqual(
+                    (
+                        result.image_format,
+                        result.mime_type,
+                        result.width,
+                        result.height,
+                    ),
+                    (
+                        expected_details[1],
+                        expected_details[2],
+                        expected_details[3],
+                        expected_details[4],
+                    ),
+                )
 
 
 class BynderSyncedVideoTests(SimpleTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -317,8 +317,8 @@ class BynderSyncedImageTests(SimpleTestCase):
         self.assertEqual(state_before, self.obj.__dict__)
 
     @override_settings(
-        BYNDER_IMAGE_MAX_WIDTH=100,
-        BYNDER_IMAGE_MAX_HEIGHT=100,
+        BYNDER_MAX_SOURCE_IMAGE_WIDTH=100,
+        BYNDER_MAX_SOURCE_IMAGE_HEIGHT=100,
         WAGTAILIMAGES_FORMAT_CONVERSIONS={"gif": "png", "bmp": "png", "tiff": "jpeg"},
     )
     def test_convert_downloaded_image(self):


### PR DESCRIPTION
NOTE: Includes changes from #31, which should be reviewed/merged first

Contrary to what you might think from reviewing [the documentation on the subject](https://support.bynder.com/hc/en-us/articles/360013931139-Create-Image-Derivatives-Asset-Variations), setting up custom derivatives that appear in API responses alongside the default `mini`, `thul` and `webimage` values is quite limited, and my client couldn't find a way to reliably restrict the dimensions for `WagtailSource` as we had agreed.

Since Wagtail has everything we need to manipulate images on-the-fly, I thought a sensible way to avoid unreasonably large images from making it into a library (a leading cause of memory usage issues on Wagtail sites) would be to introduce the `BYNDER_SOURCE_IMAGE_MAX_WIDTH` and `BYNDER_SOURCE_IMAGE_MAX_HEIGHT` settings, and use them to check and downsize downloaded images before using them to set the source file.