### PR TITLE
Wagtail 63 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         db: ["postgres"]
 
     services:

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,14 @@
 min_version = 4.11
 
 envlist =
-    py{3.11,3.12}-django{4.2,5.0}-wagtail{5.2,6.1}
+    py{3.11,3.12}-django{4.2,5.0}-wagtail{5.2,6.1,6.2,6.3}
+    py3.13-django5.1-wagtail6.3
 
 [gh-actions]
 python =
     3.11: py3.11
     3.12: py3.12
+    3.13: py3.13
 
 [gh-actions:env]
 DB =
@@ -33,9 +35,12 @@ extras = testing
 deps =
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
+    django5.1: Django>=5.1,<5.2
 
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.1: wagtail>=6.1,<6.2
+    wagtail6.2: wagtail>=6.2,<6.3
+    wagtail6.3: wagtail>=6.3,<6.4
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.9


### PR DESCRIPTION
This pull request introduces changes to support new versions of Python and Wagtail in the project.

### Support for new Python and Wagtail versions:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L67-R67): Added Python 3.13 to the matrix of Python versions for testing.
* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L5-R12): Added Python 3.13 and Wagtail 6.2, 6.3 to the testing environments. Included dependencies for Django 5.1 and Wagtail 6.2, 6.3. [[1]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L5-R12) [[2]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R38-R43)

### Conditional imports for Wagtail versions:

* [`src/wagtail_bynder/views/document.py`](diffhunk://#diff-e471eca6b9e3c7975d7a55ea632fa1baab7e8a9319fbf33c40b355764b6c24b5R5-R14): Added conditional imports and class definitions to support Wagtail versions below and above 6.3. [[1]](diffhunk://#diff-e471eca6b9e3c7975d7a55ea632fa1baab7e8a9319fbf33c40b355764b6c24b5R5-R14) [[2]](diffhunk://#diff-e471eca6b9e3c7975d7a55ea632fa1baab7e8a9319fbf33c40b355764b6c24b5R23-R24) [[3]](diffhunk://#diff-e471eca6b9e3c7975d7a55ea632fa1baab7e8a9319fbf33c40b355764b6c24b5L33-R46)
* [`src/wagtail_bynder/views/image.py`](diffhunk://#diff-ad81b64c46ac21cfbc1faad2208da94f56d7a92702e8b61a40b4beee9fc58613R5-R14): Added conditional imports and class definitions to support Wagtail versions below and above 6.3. [[1]](diffhunk://#diff-ad81b64c46ac21cfbc1faad2208da94f56d7a92702e8b61a40b4beee9fc58613R5-R14) [[2]](diffhunk://#diff-ad81b64c46ac21cfbc1faad2208da94f56d7a92702e8b61a40b4beee9fc58613R23-R24) [[3]](diffhunk://#diff-ad81b64c46ac21cfbc1faad2208da94f56d7a92702e8b61a40b4beee9fc58613L33-R46)