### PR TITLE
Support/wagtail 7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: ["3.13"]
         django: ["5.1"]
-        wagtail: ["6.3"]
+        wagtail: ["6.4"]
         db: ["postgres"]
 
     services:
@@ -77,7 +77,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
         django: ["4.2"]
-        wagtail: ["5.2", "6.1", "6.2"]
+        wagtail: ["5.2", "6.3"]
         db: ["sqlite"]
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7] - unreleased
+## Unreleased
+
+### Added
+
+- Support for Wagtail 6.4
+
+### Changed
+
+- Image chooser tests now include new `default_alt_text` property
+
+## Removed
+
+- Wagtail versions (6.0-6.2) from tox testing matrix
+
+## [0.7] - 2025-01-15
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -366,4 +366,4 @@ Supported versions:
 
 - Python 3.11, 3.12, 3.13
 - Django 4.2, 5.0, 5.1
-- Wagtail 5.2 (LTS), 6.0, 6.1, 6.2, 6.3 (LTS)
+- Wagtail 5.2 (LTS), 6.3 (LTS), 6.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",

--- a/tests/test_image_chooser_views.py
+++ b/tests/test_image_chooser_views.py
@@ -32,7 +32,6 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
         # return a test image instead of creating its own
 
         image = CustomImageFactory.create()
-        print(image)
         with mock.patch(
             "wagtail_bynder.views.image.ImageChosenView.create_object",
             return_value=image,

--- a/tests/test_image_chooser_views.py
+++ b/tests/test_image_chooser_views.py
@@ -30,7 +30,9 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
     def test_creates_image_if_asset_id_not_recognised(self):
         # For expediency and predictability, have create_object()
         # return a test image instead of creating its own
+
         image = CustomImageFactory.create()
+        print(image)
         with mock.patch(
             "wagtail_bynder.views.image.ImageChosenView.create_object",
             return_value=image,
@@ -49,6 +51,7 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                     "title": image.title,
                     "preview": mock.ANY,
                     "edit_url": reverse("wagtailimages:edit", args=[image.id]),
+                    "default_alt_text": image.title,
                 },
             },
         )
@@ -76,6 +79,7 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                     "title": image.title,
                     "preview": mock.ANY,
                     "edit_url": reverse("wagtailimages:edit", args=[image.id]),
+                    "default_alt_text": image.title,
                 },
             },
         )
@@ -103,6 +107,7 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                     "title": image.title,
                     "preview": mock.ANY,
                     "edit_url": reverse("wagtailimages:edit", args=[image.id]),
+                    "default_alt_text": image.title,
                 },
             },
         )

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version = 4.11
 
 envlist =
-    py{3.11,3.12}-django{4.2,5.0}-wagtail{5.2,6.1,6.2,6.3}
-    py3.13-django5.1-wagtail6.3
+    py{3.11,3.12}-django{4.2,5.0}-wagtail{5.2,6.3,6.4}
+    py3.13-django5.1-wagtail{6.3,6.4}
 
 [gh-actions]
 python =
@@ -36,11 +36,9 @@ deps =
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
-
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.1: wagtail>=6.1,<6.2
-    wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.9

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 min_version = 4.11
 
 envlist =
-    py{3.11,3.12}-django{4.2,5.0}-wagtail{5.2,6.3,6.4}
-    py3.13-django5.1-wagtail{6.3,6.4}
+    py{3.11,3.12}-django4.2-wagtail{5.2,6.3,6.4}
+    py3.13-django5.1-wagtail{6.3,6.4,7.0}
+    py3.13-django5.2-wagtail{6.3,6.4,7.0}
 
 [gh-actions]
 python =
@@ -34,11 +35,11 @@ extras = testing
 
 deps =
     django4.2: Django>=4.2,<4.3
-    django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
-    wagtail5.2: wagtail>=5.2,<5.3
+    django5.2: Django>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.9


### PR DESCRIPTION
This PR updates the test matrix for Wagtail 7 on top of the changes added in #37 

> This pull request introduces changes to support Wagtail 6.4.
> 
> [.github/workflows/test.yml](https://github.com/torchbox/wagtail-bynder/pull/37/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88):
> Updated the latest test to use Wagtail 6.4 and the legacy test to use Wagtail 6.3 (LTS) in addition to version 5.2.
> [tox.ini](https://github.com/torchbox/wagtail-bynder/pull/37/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449):
> Added Wagtail 6.4 to the testing environments and removed out-of-support versions of Wagtail (6.1 and 6.2).
> [tests/test_image_chooser_views.py](https://github.com/torchbox/wagtail-bynder/pull/37/files#diff-bceb572b908f9c13f68d2efbcbf8996755fcb442aee6cc6dccfb17ae1a974703):
> Added the new default_alt_text image property to test assertions
> [pyproject.toml](https://github.com/torchbox/wagtail-bynder/pull/37/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711):
> Added Python 3.13 trove classifier
> [README.md](https://github.com/torchbox/wagtail-bynder/pull/37/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5):
> Removed removed out-of-support versions of Wagtail (6.0-6.2).
> [CHANGELOG.md](https://github.com/torchbox/wagtail-bynder/pull/37/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed):
> Added draft unreleased section