### PR TITLE
Wagtail 7.4 Maintenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
           cache: "pip"
           cache-dependency-path: "**/pyproject.toml"
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     # Keep in sync with .pre-commit-config.yaml
-    - run: python -Im pip install --user ruff==0.5.0
+    - run: python -Im pip install --user ruff==0.15.14
 
     - name: Run ruff
       working-directory: ./src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,36 +71,14 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
-  test-matrix:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.11"
-            django: "5.2"
-            wagtail: "7.0"
-          - python-version: "3.12"
-            django: "5.2"
-            wagtail: "7.0"
-          - python-version: "3.13"
-            django: "5.2"
-            wagtail: "7.0"
-          - python-version: "3.11"
-            django: "5.2"
-            wagtail: "7.4"
-          - python-version: "3.12"
-            django: "5.2"
-            wagtail: "7.4"
-          - python-version: "3.13"
-            django: "5.2"
-            wagtail: "7.4"
-          - python-version: "3.12"
-            django: "6.0"
-            wagtail: "7.4"
-          - python-version: "3.13"
-            django: "6.0"
-            wagtail: "7.4"
+          - python-version: ["3.11", "3.12", "3.13"]
+          - db: ["sqlite"]
     steps:
       - uses: actions/checkout@v4
 
@@ -135,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test-latest
-      - test-matrix
+      - test
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,16 +21,16 @@ env:
   TOX_TESTENV_PASSENV: FORCE_COLOR
   PIP_DISABLE_PIP_VERSION_CHECK: '1'
   PIP_NO_PYTHON_VERSION_WARNING: '1'
-  PYTHON_LATEST: '3.11'
+  PYTHON_LATEST: '3.13'
 
 jobs:
   test-latest:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
-        django: ["5.1"]
-        wagtail: ["6.3"]
+        python-version: ["3.14"]
+        django: ["6.0"]
+        wagtail: ["7.4"]
         db: ["postgres"]
 
     services:
@@ -71,14 +71,36 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
-  test-legacy:
+  test-matrix:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
-        django: ["4.2"]
-        wagtail: ["5.2", "6.1", "6.2"]
-        db: ["sqlite"]
+        include:
+          - python-version: "3.11"
+            django: "5.2"
+            wagtail: "7.0"
+          - python-version: "3.12"
+            django: "5.2"
+            wagtail: "7.0"
+          - python-version: "3.13"
+            django: "5.2"
+            wagtail: "7.0"
+          - python-version: "3.11"
+            django: "5.2"
+            wagtail: "7.4"
+          - python-version: "3.12"
+            django: "5.2"
+            wagtail: "7.4"
+          - python-version: "3.13"
+            django: "5.2"
+            wagtail: "7.4"
+          - python-version: "3.12"
+            django: "6.0"
+            wagtail: "7.4"
+          - python-version: "3.13"
+            django: "6.0"
+            wagtail: "7.4"
     steps:
       - uses: actions/checkout@v4
 
@@ -113,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test-latest
-      - test-legacy
+      - test-matrix
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ env:
   TOX_TESTENV_PASSENV: FORCE_COLOR
   PIP_DISABLE_PIP_VERSION_CHECK: '1'
   PIP_NO_PYTHON_VERSION_WARNING: '1'
-  PYTHON_LATEST: '3.13'
+  PYTHON_LATEST: '3.14'
 
 jobs:
   test-latest:
@@ -76,9 +76,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - python-version: ["3.11", "3.12", "3.13"]
-          - db: ["sqlite"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        db: ["sqlite"]
     steps:
       - uses: actions/checkout@v4
 
@@ -95,9 +94,6 @@ jobs:
         run: python -Im flit build --format wheel
 
       - name: Test
-        env:
-          TOXENV: py${{ matrix.python-version }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}-sqlite
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/wagtail_localize_git
         run: tox --installpkg ./dist/*.whl
 
       - name: ⬆️ Upload coverage data

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ ci:
   autoupdate_schedule: 'quarterly'
 
 default_language_version:
-  python: python3.11
+  python: python3.13
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # keep in sync with .github/workflows/ruff.yml
-    rev: 'v0.5.0'
+    rev: 'v0.15.14'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for Django 5.2 LTS and Django 6.0, Wagtail 7.0 LTS through 7.4 LTS
-- Support for Python 3.13 and Python 3.14.
+- Official support for Python 3.13/3.14, Django 5.2 LTS and Django 6.0, Wagtail 7.0 LTS through 7.4 LTS ([#45](https://github.com/torchbox/wagtail-bynder/pull/45)) @nickmoreton
 
 ### Removed
 
-- Support for Django 4.2, 5.0 and 5.1 (EOL), Wagtail 5.2, 6.1, 6.2 and 6.3 (outside the current Wagtail support window).
-- Dead `WAGTAIL_VERSION < (6, 3)` compatibility branches in `views/image.py` and `views/document.py`, including the
-  `ClassBasedWagtailImageEditView` / `ClassBasedDocumentEditView` shims.
+- Support for Django < 5.2, Wagtail < 7.0. ([#45](https://github.com/torchbox/wagtail-bynder/pull/45)) @nickmoreton
 
 ## [0.8.1] - 2025-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+- Support for Django 5.2 LTS and Django 6.0.
+- Support for Wagtail 7.0 LTS through 7.4 LTS.
+- Support for Python 3.13 and Python 3.14.
+
+### Removed
+
+- Support for Django 4.2, 5.0 and 5.1 (EOL).
+- Support for Wagtail 5.2, 6.1, 6.2 and 6.3 (outside the current Wagtail support window).
+- Dead `WAGTAIL_VERSION < (6, 3)` compatibility branches in `views/image.py` and `views/document.py`, including the
+  `ClassBasedWagtailImageEditView` / `ClassBasedDocumentEditView` shims.
+
+
 ## [0.8.1] - 2025-11-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ### Added
 
-- Support for Django 5.2 LTS and Django 6.0.
-- Support for Wagtail 7.0 LTS through 7.4 LTS.
+- Support for Django 5.2 LTS and Django 6.0, Wagtail 7.0 LTS through 7.4 LTS
 - Support for Python 3.13 and Python 3.14.
 
 ### Removed
 
-- Support for Django 4.2, 5.0 and 5.1 (EOL).
-- Support for Wagtail 5.2, 6.1, 6.2 and 6.3 (outside the current Wagtail support window).
+- Support for Django 4.2, 5.0 and 5.1 (EOL), Wagtail 5.2, 6.1, 6.2 and 6.3 (outside the current Wagtail support window).
 - Dead `WAGTAIL_VERSION < (6, 3)` compatibility branches in `views/image.py` and `views/document.py`, including the
   `ClassBasedWagtailImageEditView` / `ClassBasedDocumentEditView` shims.
-
 
 ## [0.8.1] - 2025-11-12
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ to manage their digital assets, which includes the images and documents used in 
 The data flow is one way: Bynder assets are always treated as the source of truth, and Wagtail uses read-only API access
 to create copies of assets and keep them up-to-date.
 
+## Compatibility
+
+- Python 3.11, 3.12, 3.13, 3.14
+- Django 5.2 LTS, 6.0
+- Wagtail 7.0 LTS, 7.1, 7.2, 7.3, 7.4 LTS
+
 ## How it works
 
 The main points of integration are Wagtail's image and document chooser views, which are patched by this app to show an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,20 +18,20 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
-    "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
 ]
 
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
-    "Django>=4.2",
-    "Wagtail>=5.2",
+    "Django>=5.2",
+    "Wagtail>=7.0",
     "bynder-sdk>=1.1.5,<2.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ testing = [
     "dj-database-url>=2.1.0,<3.0",
     "wagtail_factories>=4.1.0,<5.0",
     "responses>=0.24,<1",
-    "coverage>=7.0,<8.0",
+    "coverage>=7.10,<8.0",
     "freezegun>=1.1,<2",
 ]
 

--- a/src/wagtail_bynder/management/commands/base.py
+++ b/src/wagtail_bynder/management/commands/base.py
@@ -34,8 +34,7 @@ class BaseBynderSyncCommand(BaseModelCommand):
             "--minutes",
             type=int,
             help=_(
-                "The number of minutes into the past to look for asset "
-                "modifications."
+                "The number of minutes into the past to look for asset modifications."
             ),
         )
         parser.add_argument(

--- a/src/wagtail_bynder/models.py
+++ b/src/wagtail_bynder/models.py
@@ -296,7 +296,7 @@ class BynderSyncedImage(BynderAssetWithFileMixin, AbstractImage):
         """
 
         # Write to filesystem to avoid using memory for the same image
-        tmp = NamedTemporaryFile(mode="w+b", dir=settings.FILE_UPLOAD_TEMP_DIR)
+        tmp = NamedTemporaryFile(mode="w+b", dir=settings.FILE_UPLOAD_TEMP_DIR)  # noqa: SIM115
         details = self.convert_downloaded_image(file, tmp)
 
         # The original file is now redundant and can be deleted, making

--- a/src/wagtail_bynder/views/document.py
+++ b/src/wagtail_bynder/views/document.py
@@ -2,18 +2,10 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.utils.html import format_html
-from django.views.generic import UpdateView
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.documents import get_document_model
 from wagtail.documents.views import chooser as chooser_views
-
-
-if WAGTAIL_VERSION < (6, 3):
-    from wagtail.documents.views.documents import DeleteView
-    from wagtail.documents.views.documents import edit as document_edit
-else:
-    from wagtail.documents.views.documents import DeleteView, EditView
+from wagtail.documents.views.documents import DeleteView, EditView
 
 from wagtail_bynder.exceptions import BynderAssetDownloadError
 
@@ -24,30 +16,8 @@ if TYPE_CHECKING:
     from django.http import HttpRequest, JsonResponse
 
 
-if WAGTAIL_VERSION < (6, 3):
-
-    class ClassBasedDocumentEditView(UpdateView):
-        """
-        A class-based view that mimics the behaviour of wagtail's function-based
-        document edit view, and can be extended with view mixins.
-        """
-
-        # TODO: Use class from Wagtail once the documents app views are refactored
-        model = get_document_model()
-        pk_url_kwarg = "document_id"
-
-        def get(self, request, *args, **kwargs):
-            return document_edit(request, *args, **kwargs)
-
-        def post(self, request, *args, **kwargs):
-            return document_edit(request, *args, **kwargs)
-
-    class DocumentEditView(RedirectToBynderMixin, ClassBasedDocumentEditView):
-        pass
-else:
-
-    class DocumentEditView(RedirectToBynderMixin, EditView):
-        pass
+class DocumentEditView(RedirectToBynderMixin, EditView):
+    pass
 
 
 class DocumentDeleteView(RedirectToBynderMixin, DeleteView):

--- a/src/wagtail_bynder/views/image.py
+++ b/src/wagtail_bynder/views/image.py
@@ -2,18 +2,10 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.utils.html import format_html
-from django.views.generic import UpdateView
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.images import get_image_model
 from wagtail.images.views import chooser as chooser_views
-
-
-if WAGTAIL_VERSION < (6, 3):
-    from wagtail.images.views.images import DeleteView
-    from wagtail.images.views.images import edit as image_edit
-else:
-    from wagtail.images.views.images import DeleteView, EditView
+from wagtail.images.views.images import DeleteView, EditView
 
 from wagtail_bynder.exceptions import BynderAssetDownloadError
 
@@ -24,30 +16,8 @@ if TYPE_CHECKING:
     from django.http import HttpRequest, JsonResponse
 
 
-if WAGTAIL_VERSION < (6, 3):
-
-    class ClassBasedWagtailImageEditView(UpdateView):
-        """
-        A class-based view that mimics the behaviour of wagtail's function-based
-        image edit view, and can be extended with view mixins.
-        """
-
-        # TODO: Use class from Wagtail once the image app views are refactored
-        model = get_image_model()
-        pk_url_kwarg = "image_id"
-
-        def get(self, request, *args, **kwargs):
-            return image_edit(request, *args, **kwargs)
-
-        def post(self, request, *args, **kwargs):
-            return image_edit(request, *args, **kwargs)
-
-    class ImageEditView(RedirectToBynderMixin, ClassBasedWagtailImageEditView):
-        pass
-else:
-
-    class ImageEditView(RedirectToBynderMixin, EditView):
-        pass
+class ImageEditView(RedirectToBynderMixin, EditView):
+    pass
 
 
 class ImageDeleteView(RedirectToBynderMixin, DeleteView):

--- a/tests/test_image_chooser_views.py
+++ b/tests/test_image_chooser_views.py
@@ -51,6 +51,7 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                     "title": image.title,
                     "preview": mock.ANY,
                     "edit_url": reverse("wagtailimages:edit", args=[image.id]),
+                    "default_alt_text": mock.ANY,
                 },
             },
         )
@@ -78,6 +79,7 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                     "title": image.title,
                     "preview": mock.ANY,
                     "edit_url": reverse("wagtailimages:edit", args=[image.id]),
+                    "default_alt_text": mock.ANY,
                 },
             },
         )
@@ -105,6 +107,7 @@ class TestImageChosenView(TransactionTestCase, WagtailTestUtils):
                     "title": image.title,
                     "preview": mock.ANY,
                     "edit_url": reverse("wagtailimages:edit", args=[image.id]),
+                    "default_alt_text": mock.ANY,
                 },
             },
         )

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -1,7 +1,6 @@
 import datetime
 
 from io import StringIO
-from typing import Type
 from unittest import mock
 
 from django.core.management import call_command
@@ -45,7 +44,7 @@ class SyncCommandTestsMixin:
     """
 
     command_name: str = ""
-    command_class: Type = None
+    command_class: type = None
     uses_media_info_for_individual_assets: bool = False
 
     @classmethod
@@ -222,8 +221,8 @@ class RefreshCommandTestsMixin:
     """
 
     command_name: str = ""
-    command_class: Type
-    factory_class: Type
+    command_class: type
+    factory_class: type
 
     @classmethod
     def setUpClass(cls):
@@ -407,7 +406,7 @@ class SyncCommandErrorHandlingMixin:
     """
 
     command_name: str = ""
-    factory_class: Type
+    factory_class: type
 
     @classmethod
     def setUpTestData(cls):
@@ -472,7 +471,7 @@ class RefreshCommandErrorHandlingMixin:
     """
 
     command_name: str = ""
-    factory_class: Type
+    factory_class: type
 
     @classmethod
     def setUpTestData(cls):

--- a/tests/test_wagtail_overrides.py
+++ b/tests/test_wagtail_overrides.py
@@ -76,10 +76,10 @@ class BaseTemplateOverrideTests(TestCase, WagtailTestUtils):
         html = response.content.decode("utf-8")
 
         self.assertIn(
-            f'<script src="{ settings.STATIC_URL }wagtailadmin/js/chooser-modal-handler-factory.js">',
+            f'<script src="{settings.STATIC_URL}wagtailadmin/js/chooser-modal-handler-factory.js">',
             html,
         )
         self.assertIn(
-            f'<script src="{ settings.STATIC_URL }bynder/js/compactview-v4.0.0.js">',
+            f'<script src="{settings.STATIC_URL}bynder/js/compactview-v4.0.0.js">',
             html,
         )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ min_version = 4.11
 envlist =
     py{3.11,3.12,3.13}-django5.2-wagtail7.0
     py{3.11,3.12,3.13,3.14}-django5.2-wagtail7.4
-    py{3.12,3.13,3.14}-django6.0-wagtail7.4
+    py{3.13,3.14}-django6.0-wagtail7.4
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,16 @@
 min_version = 4.11
 
 envlist =
-    py{3.11,3.12}-django{4.2,5.0}-wagtail{5.2,6.1,6.2,6.3}
-    py3.13-django5.1-wagtail6.3
+    py{3.11,3.12,3.13}-django5.2-wagtail7.0
+    py{3.11,3.12,3.13,3.14}-django5.2-wagtail7.4
+    py{3.12,3.13,3.14}-django6.0-wagtail7.4
 
 [gh-actions]
 python =
     3.11: py3.11
     3.12: py3.12
     3.13: py3.13
+    3.14: py3.14
 
 [gh-actions:env]
 DB =
@@ -33,14 +35,11 @@ setenv =
 extras = testing
 
 deps =
-    django4.2: Django>=4.2,<4.3
-    django5.0: Django>=5.0,<5.1
-    django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
+    django6.0: Django>=6.0,<6.1
 
-    wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.1: wagtail>=6.1,<6.2
-    wagtail6.2: wagtail>=6.2,<6.3
-    wagtail6.3: wagtail>=6.3,<6.4
+    wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.4: wagtail>=7.4,<7.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.9
@@ -52,7 +51,7 @@ commands =
     python -m coverage run {toxinidir}/tests/manage.py test --deprecation all {posargs: -v 2}
 
 [testenv:coverage-report]
-base_python = python3.12
+base_python = python3.13
 package = skip
 deps =
     coverage>=7.0,<8.0
@@ -62,7 +61,7 @@ commands =
 
 [testenv:interactive]
 description = An interactive environment for local testing purposes
-basepython = python3.12
+basepython = python3.13
 
 commands_pre =
     python {toxinidir}/tests/manage.py makemigrations

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.11
 
 envlist =
-    py{3.11,3.12,3.13}-django5.2-wagtail7.0
-    py{3.11,3.12,3.13,3.14}-django5.2-wagtail7.4
-    py{3.13,3.14}-django6.0-wagtail7.4
+    py{3.11,3.12,3.13}-django5.2-wagtail7.0-{sqlite,postgres}
+    py{3.11,3.12,3.13,3.14}-django5.2-wagtail7.4-{sqlite,postgres}
+    py{3.13,3.14}-django6.0-wagtail7.4-{sqlite,postgres}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
 base_python = python3.13
 package = skip
 deps =
-    coverage>=7.0,<8.0
+    coverage>=7.10,<8.0
 commands =
     python -Im coverage combine
     python -Im coverage report -m
@@ -78,5 +78,5 @@ setenv =
 [testenv:wagtailmain]
 deps =
     flit>=3.8
-    coverage>=7.0,<8.0
+    coverage>=7.10,<8.0
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail


### PR DESCRIPTION
## Summary

- Aligns the package with current upstream support windows (as of 2026-05-26): Python 3.11–3.14, Django 5.2 LTS + 6.0, Wagtail 7.0 LTS through 7.4 LTS. Drops Django 4.2/5.0/5.1 (EOL) and Wagtail 5.2/6.1/6.2/6.3 (outside Wagtail's current support window).
- Removes the now-dead `WAGTAIL_VERSION < (6, 3)` branches in `views/image.py` and `views/document.py`, including the `ClassBasedWagtailImageEditView` / `ClassBasedDocumentEditView` shims (the new Wagtail floor is 7.0).
- Refreshes dev tooling: `pre-commit-hooks` v4.6.0 → v6.0.0, `ruff-pre-commit` v0.5.0 → v0.15.14 (with matching pin in `.github/workflows/ruff.yml`), pre-commit `default_language_version` → python3.13, `coverage>=7.10`.
- Updates `TestImageChosenView` expectations to allow Wagtail 7's new `default_alt_text` key in the chooser chosen-step response.

## Changes by file

**Production**
- `pyproject.toml` — Django/Wagtail/Python classifiers + deps refreshed; `requires-python` unchanged at `>=3.11`.
- `tox.ini` — envlist covering the valid Django × Wagtail × Python combos with explicit `{sqlite,postgres}` factor (required by tox 4.54, which rejects env names not declared in envlist).
- `.github/workflows/test.yml` — `test-latest` now Python 3.14 × Django 6.0 × Wagtail 7.4 (postgres); `test-legacy` → `test-matrix` with multiple sqlite combos; `PYTHON_LATEST` bumped to 3.13.
- `.github/workflows/publish.yml` — Python pin bumped to 3.13.
- `src/wagtail_bynder/views/image.py`, `src/wagtail_bynder/views/document.py` — dead Wagtail-version guards removed.
- `tests/test_image_chooser_views.py` — `default_alt_text: mock.ANY` added to the three `TestImageChosenView` assertions to accommodate Wagtail 7.0's response payload.
- `README.md` — added a Compatibility section.
- `CHANGELOG.md` — `[Unreleased]` entry; no version bump (release prep left to the maintainer).

**Dev tooling**
- `.pre-commit-config.yaml`, `.github/workflows/ruff.yml`, `pyproject.toml`, `tox.ini` — version bumps as described above.
- `src/wagtail_bynder/management/commands/base.py`, `tests/test_management_commands.py`, `tests/test_wagtail_overrides.py` — ruff 0.15 auto-fixes (PEP 585 lowercase `type`, implicit-string-concat collapse, f-string whitespace) + ruff-format pass.
- `src/wagtail_bynder/models.py` — added `# noqa: SIM115` to the deliberately-open `NamedTemporaryFile` in `BynderSyncedImage.process_downloaded_file` (the rest of the method depends on `tmp.name` after the call site).

## Valid matrix combinations

| Wagtail | Django | Python |
|---|---|---|
| 7.0 LTS | 5.2 | 3.11, 3.12, 3.13 |
| 7.4 LTS | 5.2 | 3.11, 3.12, 3.13, 3.14 |
| 7.4 LTS | 6.0 | 3.13, 3.14 |

## Out of scope (follow-up)

- \`bynder-sdk\` v2.0.2 is upstream but the package is still pinned to \`<2.0\`. Worth a separate PR with an API diff against the \`update_from_asset_data\` flows in \`models.py\`.

## Test plan

- [x] CI green across the new \`test-matrix\` and \`test-latest\` jobs.
- [x] Run \`tox -e py3.13-django5.2-wagtail7.0-sqlite\` locally.
- [x] Run \`tox -e py3.14-django6.0-wagtail7.4-postgres\` locally.
- [ ] Confirm \`python -m flit build --format wheel\` still produces a valid wheel.
- [x] Confirm \`pre-commit run --all-files\` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)