### PR TITLE
#47 - Setting up wagtail-bynder without BYNDER_VIDEO_MODEL throws a TypeError

### DIFF
--- a/src/wagtail_bynder/wagtail_hooks.py
+++ b/src/wagtail_bynder/wagtail_hooks.py
@@ -56,6 +56,7 @@ def editor_js():
             """,
             static("bynder/js/video-chooser-modal.js"),
         )
+    return ""
 
 
 if get_video_model():


### PR DESCRIPTION
Closes #47 

### Context

Currently, `editor_js` returns `None` if no `BYNDER_VIDEO_MODEL` is configured. This `None` gets fed into a `"".join()` which checks that the objects passed in are strings, and triggers a `TypeError` with `expected str instance, NoneType found` whenever Wagtail admin editor page is loaded.

<details><summary>Screenshot: All page editors on Wagtail admin look like this when no video model is configured</summary>

<img width="1608" height="753" alt="image" src="https://github.com/user-attachments/assets/029b60a0-882d-4d7e-aca3-4f7a1f1dac58" />

</details>

### Description of fix

In this PR, we edit `editor_js` to return an empty string instead of `None` so that we pass the correct object type to `"".join()`.